### PR TITLE
Attempt to fix click-thru using Sidebar lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+dev-notes.md

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## About
+
+**[Simple Pinterest UI](https://jovial-almeida-64a798.netlify.com/)**
+
+A web app that will be used to consume the Pinterest API on behalf of users
+to create an alternative, simple UI for viewing Boards & Pins.
+
+## Credits
+
+Web Development: Anthony Hernandez
+
+# Create React App README
+
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 
 Below you will find some information on how to perform common tasks.<br>
@@ -300,7 +313,7 @@ In the WebStorm menu `Run` select `Edit Configurations...`. Then click `+` and s
 
 Start your app by running `npm start`, then press `^D` on macOS or `F9` on Windows and Linux or click the green debug icon to start debugging in WebStorm.
 
-The same way you can debug your application in IntelliJ IDEA Ultimate, PhpStorm, PyCharm Pro, and RubyMine. 
+The same way you can debug your application in IntelliJ IDEA Ultimate, PhpStorm, PyCharm Pro, and RubyMine.
 
 ## Formatting Code Automatically
 
@@ -1717,7 +1730,7 @@ Use the following [`launch.json`](https://code.visualstudio.com/docs/editor/debu
       "name": "Debug CRA Tests",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",      
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
       "args": [
         "test",
         "--runInBand",
@@ -2031,7 +2044,7 @@ If you’re using [Apache HTTP Server](https://httpd.apache.org/), you need to c
     RewriteRule ^ index.html [QSA,L]
 ```
 
-It will get copied to the `build` folder when you run `npm run build`. 
+It will get copied to the `build` folder when you run `npm run build`.
 
 If you’re using [Apache Tomcat](http://tomcat.apache.org/), you need to follow [this Stack Overflow answer](https://stackoverflow.com/a/41249464/4878474).
 
@@ -2471,7 +2484,7 @@ To resolve this:
 1. Open an issue on the dependency's issue tracker and ask that the package be published pre-compiled.
   * Note: Create React App can consume both CommonJS and ES modules. For Node.js compatibility, it is recommended that the main entry point is CommonJS. However, they can optionally provide an ES module entry point with the `module` field in `package.json`. Note that **even if a library provides an ES Modules version, it should still precompile other ES6 features to ES5 if it intends to support older browsers**.
 
-2. Fork the package and publish a corrected version yourself. 
+2. Fork the package and publish a corrected version yourself.
 
 3. If the dependency is small enough, copy it to your `src/` folder and treat it as application code.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-scripts": "1.1.5"
+    "react-scripts": "1.1.5",
+    "react-sidebar": "^3.0.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.css
+++ b/src/App.css
@@ -10,3 +10,44 @@ main p {
   text-align: center;
   font-size: large;
 }
+
+nav ul li,
+nav ul li a {
+  color: teal;
+}
+
+
+
+/*
+  SIDE BAR STYLES
+*/
+
+.side-bar__content {
+
+}
+
+.side-bar__content ul {
+  /* Consume entire height of side-drawer */
+  height: 100%;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  /* Position links at top of side-drawer */
+  justify-content: flex-start;
+  top: 0;
+}
+
+.side-bar__content li {
+  margin: 0.5rem 0;
+}
+
+.side-bar__content a {
+  color: teal;
+  text-decoration: none;
+  font-size: 1.2rem;
+}
+
+.side-bar__content a:hover,
+.side-bar__content a:active {
+  color: #ff8100;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,55 +1,64 @@
 import React, { Component } from 'react';
 import Toolbar from './components/Toolbar/Toolbar';
-import SideDrawer from './components/SideDrawer/SideDrawer';
-import Backdrop from './components/Backdrop/Backdrop';
+// https://github.com/balloob/react-sidebar#readme
+import Sidebar from "react-sidebar";
 import './App.css';
 
 class App extends Component {
 
   state = {
-    sideDrawerOpen: false
+    sideBarOpen: false
   };
 
-  drawerToggleClickHandler = () => {
-    this.setState((prevState) => {
-      // We prevent async/batch update issues by using prevState as a arg
-      // instead of just doing something like:
-      // this.setState({ sideDrawerOpen: !this.state.sideDrawerOpen });
-      return { sideDrawerOpen: !prevState.sideDrawerOpen };
-    })
+  openSideBar = (open) => {
+    this.setState({ sideBarOpen: open });
   };
 
-  backdropClickHandler = () => {
-    // No need to worry about async/batch updates issue since clicking backdrop
-    // should always result in a closed drawer (regardless if it's open or not)
-    // If we introduce other components, like a modal, that would depend on this
-    // functionality, we would simply also set their states to "closed" here too
-    this.setState({ sideDrawerOpen: false });
-  }
+  sideBarStyles = () => {
+    return {
+      sidebar: {
+        background: "white",
+        width: "300px",
+        maxWidth: "70%",
+        height: "100%",
+        position: "fixed",
+      }
+    }
+  };
 
-  renderBackdrop = () => {
-    // Can also be based on other conditions, like a modal being open
-    if (this.state.sideDrawerOpen) {
-      return (
-        <Backdrop
-          click={this.backdropClickHandler}
-        />
-      );
-    };
+  renderSideBarContent = () => {
+    return (
+      <nav className="side-bar__content">
+        <ul>
+          <li>
+            <a href="/">
+              Board Name 1
+            </a>
+          </li>
+
+          <li>
+            <a href="/">
+              Board Name 2
+            </a>
+          </li>
+        </ul>
+      </nav>
+    );
   };
 
   render() {
     return (
       <div className="App">
-        <Toolbar
-          drawerClickHandler={this.drawerToggleClickHandler}
-        />
-
-        <SideDrawer
-          show={this.state.sideDrawerOpen}
-        />
-
-        { this.renderBackdrop() }
+        <Sidebar
+          sidebar={this.renderSideBarContent()}
+          styles={this.sideBarStyles()}
+          open={this.state.sideBarOpen}
+          onSetOpen={this.openSideBar}
+        >
+          <Toolbar
+            drawerClickHandler={this.openSideBar}
+          />
+        </Sidebar>
 
         <main>
           <p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@>=7.0.0-beta.56":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -3877,11 +3883,7 @@ js-base64@^2.1.9:
   version "2.4.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
 
-"js-tokens@^3.0.0 || ^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-
-js-tokens@^3.0.2:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
@@ -5428,7 +5430,7 @@ react-dev-utils@^5.0.2:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@16.5.0:
+react-dom@^16.5.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.0.tgz#57704e5718669374b182a17ea79a6d24922cb27d"
   dependencies:
@@ -5486,7 +5488,14 @@ react-scripts@1.1.5:
   optionalDependencies:
     fsevents "^1.1.3"
 
-react@16.5.0:
+react-sidebar@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-sidebar/-/react-sidebar-3.0.2.tgz#cf695b5a78098e70460c847fb0c6c81cfd896c37"
+  dependencies:
+    "@babel/runtime" ">=7.0.0-beta.56"
+    prop-types "^15.6.2"
+
+react@^16.5.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.5.0.tgz#f2c1e754bf9751a549d9c6d9aca41905beb56575"
   dependencies:
@@ -5589,6 +5598,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"


### PR DESCRIPTION
On iPhones, it's currently possible to select text behind the side nav (when it's opened), which is annoying. Let's see if this fixes that, while introducing a nice, additional feature (slide it open like a native app). Also, can look into implementing a responsive side-nav (open by default if screen has enough space): https://github.com/balloob/react-sidebar#responsive-sidebar.

**Using Sidebar Library: https://github.com/balloob/react-sidebar**

