### PR TITLE
Improve SideDrawer Clickability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## About
+
+**[Simple Pinterest UI](https://jovial-almeida-64a798.netlify.com/)**
+
+A web app that will be used to consume the Pinterest API on behalf of users
+to create an alternative, simple UI for viewing Boards & Pins.
+
+## Credits
+
+Web Development: Anthony Hernandez
+
+# Create React App README
+
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 
 Below you will find some information on how to perform common tasks.<br>
@@ -300,7 +313,7 @@ In the WebStorm menu `Run` select `Edit Configurations...`. Then click `+` and s
 
 Start your app by running `npm start`, then press `^D` on macOS or `F9` on Windows and Linux or click the green debug icon to start debugging in WebStorm.
 
-The same way you can debug your application in IntelliJ IDEA Ultimate, PhpStorm, PyCharm Pro, and RubyMine. 
+The same way you can debug your application in IntelliJ IDEA Ultimate, PhpStorm, PyCharm Pro, and RubyMine.
 
 ## Formatting Code Automatically
 
@@ -1717,7 +1730,7 @@ Use the following [`launch.json`](https://code.visualstudio.com/docs/editor/debu
       "name": "Debug CRA Tests",
       "type": "node",
       "request": "launch",
-      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",      
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
       "args": [
         "test",
         "--runInBand",
@@ -2031,7 +2044,7 @@ If you’re using [Apache HTTP Server](https://httpd.apache.org/), you need to c
     RewriteRule ^ index.html [QSA,L]
 ```
 
-It will get copied to the `build` folder when you run `npm run build`. 
+It will get copied to the `build` folder when you run `npm run build`.
 
 If you’re using [Apache Tomcat](http://tomcat.apache.org/), you need to follow [this Stack Overflow answer](https://stackoverflow.com/a/41249464/4878474).
 
@@ -2471,7 +2484,7 @@ To resolve this:
 1. Open an issue on the dependency's issue tracker and ask that the package be published pre-compiled.
   * Note: Create React App can consume both CommonJS and ES modules. For Node.js compatibility, it is recommended that the main entry point is CommonJS. However, they can optionally provide an ES module entry point with the `module` field in `package.json`. Note that **even if a library provides an ES Modules version, it should still precompile other ES6 features to ES5 if it intends to support older browsers**.
 
-2. Fork the package and publish a corrected version yourself. 
+2. Fork the package and publish a corrected version yourself.
 
 3. If the dependency is small enough, copy it to your `src/` folder and treat it as application code.
 

--- a/src/App.js
+++ b/src/App.js
@@ -53,6 +53,7 @@ class App extends Component {
 
         <main>
           <p>
+            <br />
             Going to build an app that will be used to acquire access to the
             Pinterest API.
             <br />

--- a/src/components/SideDrawer/SideDrawer.css
+++ b/src/components/SideDrawer/SideDrawer.css
@@ -34,16 +34,25 @@
   /* Position links at top of side-drawer */
   justify-content: flex-start;
   top: 0;
+  padding-top: 2rem;
+  padding-left: 2rem;
+  margin-top: 0;
 }
 
 .side-drawer li {
-  margin: 0.5rem 0;
+  height: 5rem;
+  text-align: center;
 }
 
 .side-drawer a {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
   color: teal;
   text-decoration: none;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
 }
 
 .side-drawer a:hover,

--- a/src/components/SideDrawer/SideDrawer.css
+++ b/src/components/SideDrawer/SideDrawer.css
@@ -35,7 +35,7 @@
   justify-content: flex-start;
   top: 0;
   padding-top: 2rem;
-  padding-left: 2rem;
+  padding-left: 0;
   margin-top: 0;
 }
 

--- a/src/components/SideDrawer/SideDrawer.js
+++ b/src/components/SideDrawer/SideDrawer.js
@@ -14,15 +14,19 @@ const sideDrawer = props => {
     <nav className={drawerClasses}>
       <ul>
         <li>
-          <a href="/">
-            Board Name 1
-          </a>
+          <a href="/">Board Name 1</a>
         </li>
 
         <li>
-          <a href="/">
-            Board Name 2
-          </a>
+          <a href="/">Board Name 2</a>
+        </li>
+
+        <li>
+          <a href="/">Board Name 3</a>
+        </li>
+
+        <li>
+          <a href="/">Board Name 4</a>
         </li>
       </ul>
     </nav>

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -25,15 +25,19 @@ const Toolbar = props => (
       <div className="toolbar__navigation-items">
         <ul>
           <li>
-            <a href="/">
-              Board Name 1
-            </a>
+            <a href="/">Board Name 1</a>
           </li>
 
           <li>
-            <a href="/">
-              Board Name 2
-            </a>
+            <a href="/">Board Name 2</a>
+          </li>
+
+          <li>
+            <a href="/">Board Name 3</a>
+          </li>
+
+          <li>
+            <a href="/">Board Name 4</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
The SideDrawer links were difficult to click (you literally need to click the link, cannot miss it), leading to clicking content behind the SideDrawer when on an iPhone if not clicking accurately. This proved annoying very quickly, so this so address that issue, while improving the links' clickability overall.